### PR TITLE
Make cogs work with latest aiohttp.

### DIFF
--- a/animal/animal.py
+++ b/animal/animal.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from __main__ import send_cmd_help
 
+
 class Animal:
     """Animal commands."""
 

--- a/animal/animal.py
+++ b/animal/animal.py
@@ -1,20 +1,20 @@
 import discord
 from discord.ext import commands
 from __main__ import send_cmd_help
-import aiohttp
 
 class Animal:
     """Animal commands."""
 
     def __init__(self, bot):
         self.bot = bot
+        swlf.session = self.bot.http.session
 
     @commands.command()
     async def cats(self):
         """Shows a cat"""
         search = "http://random.cat/meow"
         try:
-            async with aiohttp.get(search) as r:
+            async with self.session.get(search) as r:
                 result = await r.json()
             await self.bot.say(result['file'])
         except:
@@ -31,7 +31,7 @@ class Animal:
             amount = 5
         try:
             for x in range(0,amount):
-                async with aiohttp.get(search) as r:
+                async with self.session.get(search) as r:
                     api_result = await r.json()
                     results.append(api_result['file'])
             await self.bot.say("\n".join(results)) # \o/ Thanks irdumb <3
@@ -43,7 +43,7 @@ class Animal:
         """Shows a pug"""
         search = "http://pugme.herokuapp.com/random"
         try:
-            async with aiohttp.get(search) as r:
+            async with self.session.get(search) as r:
                 result = await r.json()
             await self.bot.say(result['pug'])
         except:
@@ -60,7 +60,7 @@ class Animal:
             amount = 5
         try:
             for x in range(0,amount):
-                async with aiohttp.get(search) as r:
+                async with self.session.get(search) as r:
                     api_result = await r.json()
                     results.append(api_result['pug'])
             await self.bot.say("\n".join(results)) # \o/ Thanks irdumb <3

--- a/animal/animal.py
+++ b/animal/animal.py
@@ -7,7 +7,7 @@ class Animal:
 
     def __init__(self, bot):
         self.bot = bot
-        swlf.session = self.bot.http.session
+        self.session = self.bot.http.session
 
     @commands.command()
     async def cats(self):

--- a/doujin/doujin.py
+++ b/doujin/doujin.py
@@ -1,13 +1,14 @@
 import discord
 from discord.ext import commands
-import aiohttp
 from __main__ import send_cmd_help
+
 
 class Doujin:
     """Doujin commands."""
 
     def __init__(self, bot):
         self.bot = bot
+	self.session = self.bot.http.session
 
     @commands.group(pass_context=True)
     async def doujin(self, ctx):
@@ -19,21 +20,21 @@ class Doujin:
     async def nhentai(self):
         """Sends a random doujin"""
         url = "http://nhentai.net/random/"
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             await self.bot.say(r.url)
 			
     @doujin.command(no_pm=True)
     async def tsumino(self):
         """Sends a random doujin"""
         url = "http://www.tsumino.com/Browse/Random"
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             await self.bot.say(r.url)
 			
     @doujin.command(no_pm=True)
     async def hbrowse(self):
         """Sends a random doujin"""
         url = "http://www.hbrowse.com/random"
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             await self.bot.say(r.url)
 
 def setup(bot):

--- a/nsfw/nsfw.py
+++ b/nsfw/nsfw.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands
 from __main__ import send_cmd_help
-import aiohttp
 from bs4 import BeautifulSoup
 import random
 
@@ -11,6 +10,7 @@ class Nsfw:
 
     def __init__(self, bot):
         self.bot = bot
+        self.session = self.bot.http.session
 
     @commands.group(pass_context=True)
     async def nsfw(self, ctx):
@@ -23,7 +23,7 @@ class Nsfw:
         """Random Image From Yandere"""
         try:
             query = ("https://yande.re/post/random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="highres").get("href")
@@ -36,7 +36,7 @@ class Nsfw:
         """Random Image From Konachan"""
         try:
             query = ("https://konachan.com/post/random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="highres").get("href")
@@ -49,7 +49,7 @@ class Nsfw:
         """Random Image From e621"""
         try:
             query = ("https://e621.net/post/random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="highres").get("href")
@@ -62,7 +62,7 @@ class Nsfw:
         """Random Image From rule34"""
         try:
             query = ("http://rule34.xxx/index.php?page=post&s=random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -75,7 +75,7 @@ class Nsfw:
         """Random Image From Danbooru"""
         try:
             query = ("http://danbooru.donmai.us/posts/random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -88,7 +88,7 @@ class Nsfw:
         """Random Image From Gelbooru"""
         try:
             query = ("http://www.gelbooru.com/index.php?page=post&s=random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -101,7 +101,7 @@ class Nsfw:
         """Random Image From DrunkenPumken"""
         try:
             query = ("http://www.tbib.org/index.php?page=post&s=random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -114,7 +114,7 @@ class Nsfw:
         """Random Image From Xbooru"""
         try:
             query = ("http://xbooru.com/index.php?page=post&s=random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -127,7 +127,7 @@ class Nsfw:
         """Random Image From Furrybooru"""
         try:
             query = ("http://furry.booru.org/index.php?page=post&s=random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -140,7 +140,7 @@ class Nsfw:
         """Random Image From DrunkenPumken"""
         try:
             query = ("http://drunkenpumken.booru.org/index.php?page=post&s=random")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -153,7 +153,7 @@ class Nsfw:
         """Random Image From Lolibooru"""
         try:
             query = ("https://lolibooru.moe/post/random/")
-            page = await aiohttp.get(query)
+            page = await self.session.get(query)
             page = await page.text()
             soup = BeautifulSoup(page, 'html.parser')
             image = soup.find(id="image").get("src")
@@ -171,7 +171,7 @@ class Nsfw:
             try:
                 tags = ("+").join(tags)
                 query = ("https://yande.re/post.json?limit=42&tags=" + tags)
-                page = await aiohttp.get(query)
+                page = await self.session.get(query)
                 json = await page.json()
                 if json != []:
                     await self.bot.say(random.choice(json)['jpeg_url'])


### PR DESCRIPTION
Since aiohttp v1.3.2 aiohttp.get and other deprecated functions that was not part of ClientSession was removed. As such let's use discord.py's instance instead.

This PR has multiple commits to cover all cogs that use these old finctions of aiohttp.